### PR TITLE
Added global variable for settingsUI-width

### DIFF
--- a/POE-ItemInfo.ahk
+++ b/POE-ItemInfo.ahk
@@ -172,6 +172,7 @@ class Globals {
 Globals.Set("AHKVersionRequired", AHKVersionRequired)
 Globals.Set("ReleaseVersion", ReleaseVersion)
 Globals.Set("DataDir", A_ScriptDir . "\data")
+Globals.Set("SettingsUIWidth", 545)
 global SuspendPOEItemScript = 0
 
 class UserOptions {
@@ -7279,7 +7280,8 @@ ShowSettingsUI()
     SetTimer, ToolTipTimer, Off
     ToolTip
     Fonts.SetUIFont(9)
-    Gui, Show, w545 h710, PoE Item Info Settings
+    SettingsUIWidth := Globals.Get("SettingsUIWidth", 545)
+    Gui, Show, w%SettingsUIWidth% h710, PoE Item Info Settings
 }
 
 IniRead(ConfigPath, Section_, Key, Default_) 


### PR DESCRIPTION
Requesting this change to help me with our TradeMacro. I'd like to add some settings to PoE-ItemInfos Settings UI and need to change the window width to manage that. By using a global variable for the width I can overwrite the window dimensions without touching ItemInfos code.
