### PR TITLE
Fixed SubType and TypeName being empty on magic and normal items

### DIFF
--- a/POE-ItemInfo.ahk
+++ b/POE-ItemInfo.ahk
@@ -6271,6 +6271,7 @@ ParseItemData(ItemDataText, ByRef RarityLevel="")
     Item.IsCorrupted := False
     Item.IsMirrored := False
     Item.HasEffect := False
+    Item.HasImplicit := False
     
     ResetAffixDetailVars()
     
@@ -6289,7 +6290,7 @@ ParseItemData(ItemDataText, ByRef RarityLevel="")
 
     ItemData.NamePlate := ItemDataParts1
     ItemData.Stats := ItemDataParts2
-    
+
     ItemDataIndexLast := ItemDataParts0
     ItemDataPartsLast := ItemDataParts%ItemDataIndexLast%
     ItemData.ClearParts()
@@ -6416,7 +6417,7 @@ ParseItemData(ItemDataText, ByRef RarityLevel="")
         }
     }
     
-    ItemDataIndexAffixes := ItemData.IndexLast - GetNegativeAffixOffset(Item)
+    ItemDataIndexAffixes := ItemData.IndexLast - GetNegativeAffixOffset(Item)    
     If (ItemDataIndexAffixes <= 0)
     {
         ; ItemDataParts doesn't have the parts/text we need. Bail. 
@@ -6425,7 +6426,24 @@ ParseItemData(ItemDataText, ByRef RarityLevel="")
     }
     ItemData.Affixes := ItemDataParts%ItemDataIndexAffixes%
     ItemData.IndexAffixes := ItemDataIndexAffixes
-    
+
+    ; Retrieve items implicit mod if it has one
+    If (Item.IsWeapon or Item.IsArmour or Item.IsRing or Item.IsBelt or Item.IsAmulet) {
+        ; Magic and higher rarity
+        If (RarityLevel > 1) {
+            ItemDataIndexImplicit := ItemData.IndexLast - GetNegativeAffixOffset(Item) - 1
+        }
+        ; Normal rarity
+        Else {
+            ItemDataIndexImplicit := ItemData.IndexLast - GetNegativeAffixOffset(Item)    
+        }        
+        ; Check that there is no ":" in the retrieved text = can only be an implicit mod
+        If (!InStr(ItemDataParts%ItemDataIndexImplicit%, ":")) {
+            Item.Implicit := ItemDataParts%ItemDataIndexImplicit%
+            Item.hasImplicit := True
+        }
+    }  
+
     ItemData.Stats := ItemDataParts2
 
     If (Item.IsFlask) 
@@ -6588,6 +6606,11 @@ ParseItemData(ItemDataText, ByRef RarityLevel="")
         }
 
         TT := TT . "`nQuality 20%:`n" . GemQualityDescription
+    }
+    
+    If (Item.hasImplicit and not Item.IsUnique) {
+        Implicit := Item.Implicit
+        TT = %TT%`n--------`n%Implicit% 
     }
     
     If (RarityLevel > 1 and RarityLevel < 4) 

--- a/POE-ItemInfo.ahk
+++ b/POE-ItemInfo.ahk
@@ -880,10 +880,14 @@ ParseItemType(ItemDataStats, ItemDataNamePlate, ByRef BaseType, ByRef SubType, B
         ;    the word lists used for the randomly assigned (first line) item name. 
         
         ; "$" means line end, "|" is the usual "or" operator.
-        
+        ; Using "$" perfectly matches all normal and rare items but completely fails on magic items.
+        ; I don't see a reason why "$" should be used.
+        ; There should be 2 solutions here:
+        ;   1. Don't use "$".
+        ;   2. Use Trim(RegExReplace(A_LoopField, "i) of .*", "")) to remove the suffix from magic items first.
 
         ; Shields
-        If (RegExMatch(A_LoopField, "Buckler$|Bundle$|Shield$"))
+        If (RegExMatch(A_LoopField, "Buckler|Bundle|Shield"))
         {
             BaseType = Armour
             SubType = Shield
@@ -891,7 +895,7 @@ ParseItemType(ItemDataStats, ItemDataNamePlate, ByRef BaseType, ByRef SubType, B
         }
 
         ; Gloves
-        If (RegExMatch(A_LoopField, "Gauntlets$|Gloves$|Mitts$"))
+        If (RegExMatch(A_LoopField, "Gauntlets|Gloves|Mitts"))
         {
             BaseType = Armour
             SubType = Gloves
@@ -899,7 +903,7 @@ ParseItemType(ItemDataStats, ItemDataNamePlate, ByRef BaseType, ByRef SubType, B
         }
 
         ; Boots
-        If (RegExMatch(A_LoopField, "Boots$|Greaves$|Slippers$"))
+        If (RegExMatch(A_LoopField, "Boots|Greaves|Slippers"))
         {
             BaseType = Armour
             SubType = Boots
@@ -907,7 +911,7 @@ ParseItemType(ItemDataStats, ItemDataNamePlate, ByRef BaseType, ByRef SubType, B
         }
 
         ; Helmets
-        If (RegExMatch(A_LoopField, "Bascinet$|Burgonet$|Cage$|Circlet$|Crown$|Hood$|Helm$|Helmet$|Mask$|Sallet$|Tricorne$"))
+        If (RegExMatch(A_LoopField, "Bascinet|Burgonet|Cage|Circlet|Crown|Hood|Helm|Helmet|Mask|Sallet|Tricorne"))
         {
             BaseType = Armour
             SubType = Helmet
@@ -925,12 +929,17 @@ ParseItemType(ItemDataStats, ItemDataNamePlate, ByRef BaseType, ByRef SubType, B
         }
 
         ; BodyArmour
-        If (RegExMatch(A_LoopField, "Armour$|Brigandine$|Chainmail$|Coat$|Doublet$|Garb$|Hauberk$|Jacket$|Lamellar$|Leather$|Plate$|Raiment$|Regalia$|Ringmail$|Robe$|Tunic$|Vest$|Vestment$"))
+        ; Note: Not using "$" could match "Leather Belt", therefore we first check that the item is no belt.
+        If (!RegExMatch(A_LoopField, "Belt"))
         {
-            BaseType = Armour
-            SubType = BodyArmour
-            return
+            If (RegExMatch(A_LoopField, "Armour|Brigandine|Chainmail|Coat|Doublet|Garb|Hauberk|Jacket|Lamellar|Leather|Plate|Raiment|Regalia|Ringmail|Robe|Tunic|Vest|Vestment"))
+            {
+                BaseType = Armour
+                SubType = BodyArmour
+                return
+            }
         }
+       
 
         If (RegExMatch(A_LoopField, "Chestplate|Full Dragonscale|Full Wyrmscale|Necromancer Silks|Shabby Jerkin|Silken Wrap"))
         {


### PR DESCRIPTION
SubType for magic items:
I have 2 solutions for this problem and implemented one of them. Not sure which one is better, though. The comments in the code should explain this.

TypeName for magic and normal items:
This wasn't working, too. Seems to work now.
