### PR TITLE
Fixed ItemInfo classifying Gems as Jewelry

### DIFF
--- a/POE-ItemInfo.ahk
+++ b/POE-ItemInfo.ahk
@@ -6395,7 +6395,7 @@ ParseItemData(ItemDataText, ByRef RarityLevel="")
         RarityLevel := 0
         Item.Level := ParseGemLevel(ItemDataText, "Level:")
         ItemLevelWord := "Gem Level:"
-        Item.BaseType := "Jewelry"
+        Item.BaseType := "Gem"
     }
     Else
     {


### PR DESCRIPTION
This should be an error/mistake, unless I don't see something here that I should.