### PR TITLE
added a lib function to handle script updates, can be used by other s…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,16 @@ Temporary Items
 POE-ItemInfo.ahk.bak
 .idea/
 backup/
+
+*.bak
+main.ahk
+temp/*
+temp
+trade_data/leagues.json
+trade_data/backup/*
+backup/*
+backup/
+trade_data/old_data_files/
+test.ahk
+backup/
+

--- a/Lib/PoEScripts_Update.ahk
+++ b/Lib/PoEScripts_Update.ahk
@@ -1,0 +1,82 @@
+﻿PoEScripts_Update(user, repo, ReleaseVersion, ShowUpdateNotification) {
+	GetLatestRelease(user, repo, ReleaseVersion, ShowUpdateNotification)
+	;MsgBox Hey, this LibFunction handles update checks and updates
+}
+
+GetLatestRelease(user, repo, ReleaseVersion, ShowUpdateNotification) {
+	If (ShowUpdateNotification = 0) {
+		return
+	}
+	HttpObj := ComObjCreate("WinHttp.WinHttpRequest.5.1")
+	url := "https://api.github.com/repos/" . user . "/" . repo . "/releases/latest"
+
+	Try  {
+		Encoding := "utf-8"
+		HttpObj.Open("GET",url)
+		HttpObj.SetRequestHeader("Content-type","application/html")
+		HttpObj.Send("")
+		HttpObj.WaitForResponse()   
+		html := HttpObj.ResponseText
+		
+		If Encoding {
+			oADO          := ComObjCreate("adodb.stream")
+			oADO.Type     := 1
+			oADO.Mode     := 3
+			oADO.Open()
+			oADO.Write( HttpObj.ResponseBody)
+			oADO.Position := 0
+			oADO.Type     := 2
+			oADO.Charset  := Encoding
+			html := oADO.ReadText()
+			oADO.Close()
+		}
+		
+		RegExMatch(html, "i)""tag_name"":""(.*?)""", tag)
+		RegExMatch(html, "i)""name"":""(.*?)""", vName)
+		RegExMatch(html, "i)""html_url"":""(.*?)""", url)
+		
+		tag := tag1
+		vName := vName1
+		url := url1    
+		
+		RegExReplace(tag, "^v", tag)
+          ; works only in x.x.x format
+		RegExMatch(tag, "(\d+).(\d+).(\d+)(.*)", latestVersion)
+		RegExMatch(ReleaseVersion, "(\d+).(\d+).(\d+)(.*)", currentVersion)
+		RegExMatch(html,  "i)""body"":""(.*?)""", description)
+		StringReplace, description, description1, \r\n, ~, All 
+
+		newRelease := false
+		Loop {			
+			If (not latestVersion%A_Index% and not currentVersion%A_Index%) {
+				break
+			}
+			Else If (latestVersion%A_Index% > currentVersion%A_Index%) {
+				;MsgBox % latestVersion%A_Index% "`n" currentVersion%A_Index%
+				newRelease := true
+			}			
+		}
+
+		If (newRelease) {
+			Gui, UpdateNotification:Add, Text, cGreen, Update available!
+			Gui, UpdateNotification:Add, Text, , Your installed version is <%currentVersion%>.`nThe lastest version is <%latestVersion%>.
+			Gui, UpdateNotification:Add, Link, cBlue, <a href="%url%">Download it here</a>        
+			
+			Loop, Parse, description, ~
+				Gui, UpdateNotification:Add, Text, w320, % "- " A_LoopField
+			
+			Gui, UpdateNotification:Add, Button, gCloseUpdateWindow, Close
+			yPos := A_ScreenHeight / 2 + 40
+			Gui, UpdateNotification:Show, w400 Y%yPos%, Update 
+			ControlFocus, Close, Update
+			WinWaitClose, Update
+		}
+	} Catch e {
+		MsgBox % "Update-Check failed, Github is probably down."
+	}
+	Return
+}
+
+CloseUpdateWindow:
+	Gui, Cancel
+Return

--- a/Lib/PoEScripts_Update.ahk
+++ b/Lib/PoEScripts_Update.ahk
@@ -59,7 +59,7 @@ GetLatestRelease(user, repo, ReleaseVersion, ShowUpdateNotification) {
 
 		If (newRelease) {
 			Gui, UpdateNotification:Add, Text, cGreen, Update available!
-			Gui, UpdateNotification:Add, Text, , Your installed version is <%currentVersion%>.`nThe lastest version is <%latestVersion%>.
+			Gui, UpdateNotification:Add, Text, , Your installed version is <%currentVersion%>.`nThe latest version is <%latestVersion%>.
 			Gui, UpdateNotification:Add, Link, cBlue, <a href="%url%">Download it here</a>        
 			
 			Loop, Parse, description, ~

--- a/POE-ItemInfo.ahk
+++ b/POE-ItemInfo.ahk
@@ -177,6 +177,8 @@ Globals.Set("DataDir", A_ScriptDir . "\data")
 Globals.Set("SettingsUIWidth", 545)
 Globals.Set("SettingsUIHeight", 710)
 Globals.Set("SettingsUITitle", "PoE Item Info Settings")
+Globals.Set("GithubRepo", "POE-ItemInfo")
+Globals.Set("GithubUser", "aRTy42")
 
 global SuspendPOEItemScript = 0
 
@@ -320,6 +322,18 @@ class UserOptions {
 	}
 }
 Opts := new UserOptions()
+
+; Under no circumstance set the variable "SkipItemInfoUpdateCall" in this script
+; This code block should only be called when ItemInfo runs by itself, not when it's included in other scripts like PoE-TradeMacro
+; "SkipItemInfoUpdateCall" should be set outside by other scripts
+If (!SkipItemInfoUpdateCall) {
+	; file "PoEScripts_Update.ahk" has to exist in "%A_ScriptDir%\Lib\"
+	repo := Globals.Get("GithubRepo")
+	user := Globals.Get("GithubUser")
+	ReleaseVersion := Globals.Get("ReleaseVersion")
+	ShowUpdateNotification := 1
+	PoEScripts_Update(user, repo, ReleaseVersion, ShowUpdateNotification)
+}
 
 class Fonts {
 

--- a/POE-ItemInfo.ahk
+++ b/POE-ItemInfo.ahk
@@ -6341,7 +6341,8 @@ ParseItemData(ItemDataText, ByRef RarityLevel="")
 	}
 
 	; Divination Card detection = Normal rarity with stack size (100% valid??)
-	If (InStr(ItemData.Rarity, "Divination Card") and InStr(ItemDataText, "Stack Size:"))
+	; Cards like "The Void" don't have a stack size
+	If (InStr(ItemData.Rarity, "Divination Card"))
 	{
 		Item.IsDivinationCard := True
 		Item.BaseType := "Divination Card"


### PR DESCRIPTION
...cripts like PoE-TradeMacro

I'm thinking about implementing an auto-update function for TradeMacro, this still needs a bit of time since I'm mostly doing bug fixes atm but in a first step I thought about implementing it in a way that it can be used by ItemInfo and TradeMacro with the option to skip the function call made in ItemInfo from other scripts. This way ItemInfo can use it (if you want), but it doesn't interfere with TradeMacro which only updates from the TradeMacro repo, ignoring what's going on with the ItemInfo repo.

For now I only moved the update-check (with gui window) to a library function, seems to work with ItemInfo, it's necessary to provide the repo information and update the version.txt with the right release version number in `x.x.x` format (valid semantic versioning).

````
Globals.Set("GithubRepo", "POE-ItemInfo")
Globals.Set("GithubUser", "aRTy42")
````
