### PR TITLE
added transparency to most gui elements and changed groubox title color

### DIFF
--- a/POE-ItemInfo.ahk
+++ b/POE-ItemInfo.ahk
@@ -7584,8 +7584,18 @@ GuiAdd(ControlType, Contents, PositionInfo, AssocVar="", AssocHwnd="", AssocLabe
 	av := StrPrefix(AssocVar, "v")
 	al := StrPrefix(AssocLabel, "g")
 	ah := StrPrefix(AssocHwnd, "hwnd")
+	
+	If (ControlType = "GroupBox") {
+		Gui, Font, cDA4F49
+		Options := Param4
+	}
+	Else {
+		Options := Param4 . " BackgroundTrans "
+	}		
+	
 	GuiName := (StrLen(GuiName) > 0) ? Trim(GuiName) . ":Add" : "Add"
-	Gui, %GuiName%, %ControlType%, %PositionInfo% %av% %al% %ah% %Param4%, %Contents%
+	Gui, %GuiName%, %ControlType%, %PositionInfo% %av% %al% %ah% %Options%, %Contents%
+	Gui, Font
 }
 
 GuiAddButton(Contents, PositionInfo, AssocLabel="", AssocVar="", AssocHwnd="", Options="", GuiName="")
@@ -8000,7 +8010,7 @@ ShowUpdateNotes()
 	Loop, % Files.Length() {
 		file := Files[A_Index][1]
 		FileRead, notes, %file%
-		Gui, UpdateNotes:Add, Edit, r50 ReadOnly w700, %notes%		
+		Gui, UpdateNotes:Add, Edit, r50 ReadOnly w700 BackgroundTrans, %notes%		
 		
 		NextTab := A_Index + 1
 		Gui, UpdateNotes:Tab, %NextTab%


### PR DESCRIPTION
Had a user with some weird problems (black backgrounds for most GUI elements), the only solution we found was adding transperancy (option "BackgroundTrans"). Doing this for GroupBoxes is bad because the line behind the text would be visible then. Solution to this was to change the groupbox text color, now it should be readable in all cases (even with black background).

![meh](https://cloud.githubusercontent.com/assets/16058242/22345739/a1486a7e-e401-11e6-8d65-c37d89b33588.jpg)
