### PR TITLE
Item highlighting improvements/fixes

### DIFF
--- a/resources/ahk/POE-ItemInfo.ahk
+++ b/resources/ahk/POE-ItemInfo.ahk
@@ -9803,6 +9803,8 @@ HighlightItems(broadTerms = false, leaveSearchField = true, deadKeysWorkaround =
 				; some keyboard layouts translate special characters like ^ ' " ` ~ combined with e/i/u/o/a into a special character, for example Dutch: ë (dead keys)
 				; solution: add a space after every one of those characters
 				If (deadKeysWorkaround) {
+					
+					/*
 					If (RegExMatch(val, "i)^[eioau]")) {
 						; space after opening quotation mark only needed for vowels
 						searchText = %searchText% " %val%"
@@ -9816,8 +9818,10 @@ HighlightItems(broadTerms = false, leaveSearchField = true, deadKeysWorkaround =
 						space := " s"
 						searchText = %searchText% %space%
 						StringTrimRight, searchText, searchText, 2
-					} 
-				} Else {				
+					}
+					*/
+					searchText = %searchText% "%val%"
+				} Else {		
 					searchText = %searchText% "%val%"
 				}			
 			}
@@ -9829,29 +9833,29 @@ HighlightItems(broadTerms = false, leaveSearchField = true, deadKeysWorkaround =
 				; make sure we have an equal amount of quotation marks (all terms properly enclosed)
 				If (QuotationMarks&1) {
 					If (deadKeysWorkaround) {
-						searchText := RegExReplace(newString, "i).{2}$", """ ")
+						;searchText := RegExReplace(newString, "i).{2}$", """ ")
+						searchText := RegExReplace(newString, "i).$", """")
 					} Else {
 						searchText := RegExReplace(newString, "i).$", """")
 					}					
 				}
 			}
-			
-			SendInput %searchText%
+
+			Clipboard := searchText
+			Sleep 10
+			SendEvent ^{sc02f}		; ctrl + v
 			If (leaveSearchField) {
-				SendInput {Enter}
-			} Else {				
-				SendInput ^{A}
+				SendInput {sc01c}	; enter
+			} Else {
+				SendInput ^{sc01e}	; ctrl + a
 			}
-		} Else {
-			; send ctrl + f in case we don't have information to input
-			SendInput ^{sc021}
+		} Else {			
+			SendInput ^{sc021}		; send ctrl + f in case we don't have information to input
 		}
 
+		Sleep, 10
+		Clipboard := ClipBoardTemp
 		SuspendPOEItemScript = 0 ; Allow Item info to handle clipboard change event
-		If (Item.Name) {
-			; revert the initial clipboard upon succeeding to parse any item (doesn't cause clipboard change events otherwise)
-			Clipboard := ClipBoardTemp
-		}
 	}
 }
 

--- a/resources/ahk/POE-ItemInfo.ahk
+++ b/resources/ahk/POE-ItemInfo.ahk
@@ -9631,7 +9631,7 @@ CloseScripts() {
 	ExitApp
 }
 
-HighlightItems(broadTerms = false, leaveSearchField = true, deadKeysWorkaround = false) {
+HighlightItems(broadTerms = false, leaveSearchField = true) {
 	; Highlights items via stash search (also in vendor search)
 	IfWinActive, Path of Exile ahk_class POEWindowClass 
 	{
@@ -9799,31 +9799,8 @@ HighlightItems(broadTerms = false, leaveSearchField = true, deadKeysWorkaround =
 		If (terms.length() > 0) {
 			SendInput ^{sc021} ; sc021 = f
 			searchText =
-			For key, val in terms {
-				; some keyboard layouts translate special characters like ^ ' " ` ~ combined with e/i/u/o/a into a special character, for example Dutch: ë (dead keys)
-				; solution: add a space after every one of those characters
-				If (deadKeysWorkaround) {
-					
-					/*
-					If (RegExMatch(val, "i)^[eioau]")) {
-						; space after opening quotation mark only needed for vowels
-						searchText = %searchText% " %val%"
-					} Else {
-						searchText = %searchText% "%val%"
-					}
-					
-					If (key == terms.Length()) {
-						; the last space won't be added/typed so we add a tailing character and remove it again
-						; this should result in the string ending with "{Space}
-						space := " s"
-						searchText = %searchText% %space%
-						StringTrimRight, searchText, searchText, 2
-					}
-					*/
-					searchText = %searchText% "%val%"
-				} Else {		
-					searchText = %searchText% "%val%"
-				}			
+			For key, val in terms {		
+				searchText = %searchText% "%val%"			
 			}
 
 			; the search field has a 50 character limit, we have to close the last term with a quotation mark
@@ -9831,13 +9808,8 @@ HighlightItems(broadTerms = false, leaveSearchField = true, deadKeysWorkaround =
 				newString := SubStr(searchText, 1, 50)
 				temp := RegExReplace(newString, "i)""", Replacement = "", QuotationMarks)
 				; make sure we have an equal amount of quotation marks (all terms properly enclosed)
-				If (QuotationMarks&1) {
-					If (deadKeysWorkaround) {
-						;searchText := RegExReplace(newString, "i).{2}$", """ ")
-						searchText := RegExReplace(newString, "i).$", """")
-					} Else {
-						searchText := RegExReplace(newString, "i).$", """")
-					}					
+				If (QuotationMarks&1) {					
+					searchText := RegExReplace(newString, "i).$", """")				
 				}
 			}
 

--- a/resources/ahk/default_AdditionalMacros.txt
+++ b/resources/ahk/default_AdditionalMacros.txt
@@ -8,12 +8,11 @@
 	Pause::TogglePOEItemScript()			; Pause item parsing with the pause key (other macros remain).
 	#D::WinMinimize, A						; Winkey+D minimizes the active PoE window (PoE stays minimized this way).
    
-	^F::HighlightItems(false,true,false)	; Ctrl+F fills search bars in the stash or vendor screens with the item's name or info you're hovering over.
+	^F::HighlightItems(false,true)			; Ctrl+F fills search bars in the stash or vendor screens with the item's name or info you're hovering over.
 											; Function parameters, change if needed or wanted:
 											;	1. Use broader terms, default = false.
 											;	2. Leave the search field after pasting the search terms, default = true.
-											;	3. Workaround for keyboard layouts with "dead keys", default = false. (Some Layouts need this to prevent adding special characters when using a quotation mark).
-	^!F::HighlightItems(true,true,false)	; Ctrl+Alt+F uses much broader search terms for the highlight function.
+	^!F::HighlightItems(true,true)			; Ctrl+Alt+F uses much broader search terms for the highlight function.
    
 ;	^Escape::CloseScripts()						; Ctrl+Esc closes all running scripts specified by (and including) ItemInfo or TradeMacro.
   


### PR DESCRIPTION
Removed the deadkey workaround since it's obsolete when pasting the clipboard contents into the search field instead of using `Send`.
Fixed an issue where having valid item data in the clipboard caused the highlighting function to always use that data to fill the search fields since the data was always restored.